### PR TITLE
Lighten the warning on redactions deleting data

### DIFF
--- a/docs/libraries/cape-python/redactions.md
+++ b/docs/libraries/cape-python/redactions.md
@@ -1,11 +1,11 @@
 # Redactions
 
-Redactions are functions that alter your data. Unlike [transformations](/libraries/cape-python/transformations/), which modify but preserve data, redactions delete your data.
+Redactions involve dropping the matched data. Unlike [transformations](/libraries/cape-python/transformations/), which modify but preserve data, redactions will change the shape of your dataframes.
 
 Cape Python has one built-in redaction function. This document describes what it does, and provides an example of how to use it in your policy.
 
 !!! warning
-    Redactions delete your data.
+    Redactions change the shape of your data.
 
 ## Column redaction
 
@@ -15,6 +15,6 @@ The `column-redact` redaction deletes matching columns.
 - transform:
     type: "column-redact"
     # Replace <COLUMN_NAME> with the column name you want to redact.
-    columns: ["<COLUMN_NAME>"] 
+    columns: ["<COLUMN_NAME>"]
 ```
 


### PR DESCRIPTION
While redactions remove data and change the shape of your data frames
they aren't going into your database and deleting the source data.