### PR TITLE
Update the service URL in worker docs

### DIFF
--- a/docs/understand/architecture/cape-workers.md
+++ b/docs/understand/architecture/cape-workers.md
@@ -22,13 +22,15 @@ Cape workers are designed to facilitate the sharing of datasets between each oth
 Starting your Cape worker is as simple as running a Docker image using `docker run`:
 ```shell
   export CAPE_TOKEN=my-cape-org-token
-  docker run -d --rm                     \
-    --name cape-worker                   \
-    -e CAPE_TOKEN                        \
-    -e CAPE_BUCKET=my-s3-bucket-location \
-    -e AWS_ACCESS_KEY_ID                 \
-    -e AWS_SECRET_ACCESS_KEY             \
-    -e AWS_REGION                        \
+  docker run -d --rm                                  \
+    --name cape-worker                                \
+    -e CAPE_TOKEN                                     \
+    -e CAPE_BUCKET=my-s3-bucket-location              \
+    -e CAPE_COORDINATOR=https://app.capeprivacy.com   \
+    -e CAPE_BROKER=https://app.capeprivacy.com/broker \
+    -e AWS_ACCESS_KEY_ID                              \
+    -e AWS_SECRET_ACCESS_KEY                          \
+    -e AWS_REGION                                     \
     capeprivacy/cape-worker:sha-1234567
 ```
 


### PR DESCRIPTION
The current version of the worker defaults to communicating with
demo.capeprivacy.com. Since the tag has already been sent to the
customer, this doc update should get them running and delay us having to
update the tag until we have a more significant update for them.
